### PR TITLE
Require serviceName in exchanges refs

### DIFF
--- a/schemas/exchanges-reference-v0.yml
+++ b/schemas/exchanges-reference-v0.yml
@@ -99,7 +99,7 @@ properties:
           description: >-
             JSON schema for messages on this exchange. The value must be a
             relative URI, based on the service's schema location; that is, based
-            at `<rootUrl>/schemas/<serviceName`.
+            at `<rootUrl>/schemas/<serviceName>`.
       additionalProperties: false
       required:
         - type
@@ -113,6 +113,7 @@ additionalProperties: false
 required:
   - apiVersion
   - $schema
+  - serviceName
   - title
   - description
   - exchangePrefix


### PR DESCRIPTION
(and fix a typo)

This is already present in every service - it was just missed in the `required` field.